### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,14 @@ To build:
 
     ```
     $ cd public
+    ```
+    For *python2*, run:
+    ```
     $ python -m SimpleHTTPServer
+    ```
+    For *python3*, run:
+    ```
+    $ python -m http.server
     ```
 
 1. You'll need to be connected over HTTPS to access sensors (at least on iPhone), use ngrok to open up your web browser to the world via:


### PR DESCRIPTION
The SimpleHTTPServer module has been merged into http.server in Python 3. "python: command not found" error is thrown after running "python -m SimpleHTTPServer" on python3. This ensures that users using python3 are guided to run the right commands to use get up and running.